### PR TITLE
rename users DBscheme

### DIFF
--- a/migrations/0_create-table.sql
+++ b/migrations/0_create-table.sql
@@ -1,6 +1,6 @@
 CREATE TABLE IF NOT EXISTS `users` (
-	`user_id` INT AUTO_INCREMENT PRIMARY KEY,
-	`username` VARCHAR(255) NOT NULL,
+	`id` INT AUTO_INCREMENT PRIMARY KEY,
+	`name` VARCHAR(255) NOT NULL,
 	`traq_id` VARCHAR(255),
 	`github_id` VARCHAR(255),
 	`icon_url` VARCHAR(255),

--- a/src/repository/users.rs
+++ b/src/repository/users.rs
@@ -33,7 +33,7 @@ pub struct User {
 
 impl Repository {
     pub async fn get_user_by_id(&self, user_id: i64) -> anyhow::Result<User> {
-        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE user_id = ?")
+        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE id = ?")
             .bind(user_id)
             .fetch_one(&self.pool)
             .await?;


### PR DESCRIPTION
close #27 
usersのカラム名を ``user_id`` -> ``id``, ``username`` -> ``name`` と変更
APIに合わせる形にしました