### PR TITLE
セッションのセーブ、ロード等実装

### DIFF
--- a/src/repository/jwt.rs
+++ b/src/repository/jwt.rs
@@ -75,7 +75,7 @@ impl Repository {
             iat,
             nbf,
             user_id: Some(user_id),
-            email: email.to_owned(),
+            email: email.to_string(),
             action: Action::change_email,
         };
 
@@ -92,7 +92,7 @@ impl Repository {
             iat,
             nbf,
             user_id: None,
-            email: email.to_owned(),
+            email: email.to_string(),
             action: Action::register_email,
         };
 

--- a/src/repository/users_session.rs
+++ b/src/repository/users_session.rs
@@ -1,7 +1,52 @@
 use super::Repository;
-use async_session::SessionStore;
+use anyhow::Context;
+use async_session::{Session, SessionStore};
+
+use super::users::User;
 
 impl Repository {
+    pub async fn create_session(&self, user: User) -> anyhow::Result<String> {
+        let mut session = Session::new();
+        session
+            .insert("user_id", user.id)
+            .with_context(|| "Failed to insert user_id to session")?;
+        session
+            .insert("display_id", user.display_id)
+            .with_context(|| "Failed to insert display_id to session")?;
+        let result = self
+            .session_store
+            .store_session(session)
+            .await
+            .with_context(|| "Failed to store session to database")
+            .with_context(|| "Failed to create session")?;
+        match result {
+            Some(session_id) => Ok(session_id),
+            None => anyhow::bail!("unexpected error while creating session"),
+        }
+    }
+
+    pub async fn delete_session(&self, session_id: &str) -> anyhow::Result<Option<()>> {
+        let Some(session) = self
+            .session_store
+            .load_session(session_id.to_string())
+            .await?
+        else {
+            return Ok(None);
+        };
+
+        self.session_store.destroy_session(session).await?;
+        Ok(Some(()))
+    }
+
+    pub async fn get_user_id_by_session_id(&self, session_id: &str) -> anyhow::Result<Option<i64>> {
+        let session = self
+            .session_store
+            .load_session(session_id.to_owned())
+            .await?;
+
+        Ok(session.and_then(|s| s.get("user_id")))
+    }
+
     pub async fn get_display_id_by_session_id(
         &self,
         session_id: &str,

--- a/src/repository/users_session.rs
+++ b/src/repository/users_session.rs
@@ -41,7 +41,7 @@ impl Repository {
     pub async fn get_user_id_by_session_id(&self, session_id: &str) -> anyhow::Result<Option<i64>> {
         let session = self
             .session_store
-            .load_session(session_id.to_owned())
+            .load_session(session_id.to_string())
             .await?;
 
         Ok(session.and_then(|s| s.get("user_id")))
@@ -53,7 +53,7 @@ impl Repository {
     ) -> anyhow::Result<Option<i64>> {
         let session = self
             .session_store
-            .load_session(session_id.to_owned())
+            .load_session(session_id.to_string())
             .await?;
 
         Ok(session.and_then(|s| s.get("display_id")))

--- a/src/utils/mail.rs
+++ b/src/utils/mail.rs
@@ -11,7 +11,7 @@ pub async fn send_email(send_to: Address, subject: &str, message: &str) -> anyho
 
     let email = Message::builder()
         .from(Mailbox::new(
-            Some("traOJudge".to_owned()),
+            Some("traOJudge".to_string()),
             app_address.parse::<Address>().unwrap(),
         ))
         .to(Mailbox::new(None, send_to))
@@ -19,7 +19,7 @@ pub async fn send_email(send_to: Address, subject: &str, message: &str) -> anyho
         .singlepart(
             SinglePart::builder()
                 .header(header::ContentType::TEXT_PLAIN)
-                .body(message.to_owned()),
+                .body(message.to_string()),
         )?;
 
     let credentials = Credentials::new(app_address, app_password);


### PR DESCRIPTION
## 関連Issue

## 概要

セッションのセーブ、削除、`id` によるロードを実装しました。

## 変更内容

- `create_session`, `delete_session`, `get_user_id_by_session_id`

## 補足
