### PR TITLE
POST /loginを実装

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -12,7 +12,7 @@ pub fn make_router(app_state: Repository) -> Router {
     let authentication_router = Router::new()
         .route("/signup/request", post(authentication::sign_up_request))
         .route("/signup", post(authentication::sign_up))
-        .route("/login", post(authentication::login))
+        .route("/login", post(authentication::login));
 
     let users_router = Router::new()
         .route("/me", get(users::get_me).put(users::put_me))

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -11,7 +11,8 @@ mod users;
 pub fn make_router(app_state: Repository) -> Router {
     let authentication_router = Router::new()
         .route("/signup/request", post(authentication::sign_up_request))
-        .route("/signup", post(authentication::sign_up));
+        .route("/signup", post(authentication::sign_up))
+        .route("/login", post(authentication::login))
 
     let users_router = Router::new()
         .route("/me", get(users::get_me).put(users::put_me))

--- a/src/handler/authentication.rs
+++ b/src/handler/authentication.rs
@@ -133,7 +133,7 @@ pub async fn login(
     let mut headers = HeaderMap::new();
     headers.insert(
         SET_COOKIE,
-        format!("session_id={}, HttpOnly, SameSite=Strict", session_id)
+        format!("session_id={}; HttpOnly; SameSite=Strict", session_id)
             .parse()
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     );

--- a/src/handler/authentication.rs
+++ b/src/handler/authentication.rs
@@ -1,6 +1,6 @@
-use axum::{extract::State, Json};
+use axum::{extract::State, http::HeaderMap, response::IntoResponse, Json};
 use lettre::Address;
-use reqwest::StatusCode;
+use reqwest::{header::SET_COOKIE, StatusCode};
 use serde::Deserialize;
 
 use crate::{
@@ -90,4 +90,53 @@ pub async fn sign_up(
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
     Ok(StatusCode::CREATED)
+}
+
+#[derive(Deserialize)]
+pub struct LogIn {
+    email: String,
+    password: String,
+}
+
+impl Validator for LogIn {
+    fn validate(&self) -> anyhow::Result<()> {
+        RuleType::Password.validate(&self.password)?;
+        Ok(())
+    }
+}
+
+pub async fn login(
+    State(state): State<Repository>,
+    Json(body): Json<LogIn>,
+) -> Result<impl IntoResponse, StatusCode> {
+    body.validate().map_err(|_| StatusCode::BAD_REQUEST)?;
+    let user = state
+        .get_user_by_email(&body.email)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::UNAUTHORIZED)?;
+
+    let verification = state
+        .verify_user_password(user.id, &body.password)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    if !verification {
+        return Err(StatusCode::UNAUTHORIZED);
+    }
+
+    let session_id = state
+        .create_session(user)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        SET_COOKIE,
+        format!("session_id={}, HttpOnly, SameSite=Strict", session_id)
+            .parse()
+            .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    );
+
+    Ok((StatusCode::OK, headers))
 }

--- a/src/handler/authentication.rs
+++ b/src/handler/authentication.rs
@@ -133,7 +133,7 @@ pub async fn login(
     let mut headers = HeaderMap::new();
     headers.insert(
         SET_COOKIE,
-        format!("session_id={}; HttpOnly; SameSite=Strict", session_id)
+        format!("session_id={}; HttpOnly; SameSite=Lax", session_id)
             .parse()
             .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
     );

--- a/src/repository/users.rs
+++ b/src/repository/users.rs
@@ -119,6 +119,15 @@ impl Repository {
         Ok(user)
     }
 
+    pub async fn get_user_by_email(&self, email: &str) -> anyhow::Result<Option<User>> {
+        let user = sqlx::query_as::<_, User>("SELECT * FROM users WHERE email = ?")
+            .bind(email)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(user)
+    }
+
     pub async fn create_user_by_email(&self, name: &str, email: &str) -> anyhow::Result<UserId> {
         let id = UserId::new(Uuid::now_v7());
 


### PR DESCRIPTION
## 関連Issue

- close #16 
- #41 
- #40
## 概要

POST /login を実装しました。
またそれに従い、 EmailからUserを返すメソッドを実装しました。

## 変更内容

- POST login ハンドラの実装
- `Repository` に `get_user_by_email` を実装

## 補足
 **このPull RequestはPR #40 #41 の実装に依存しています、#40 #41 を先にMergeしてください**