### PR TITLE
put_me_password で  get_user_id_by_session_id を使うように変更

### DIFF
--- a/src/handler/users.rs
+++ b/src/handler/users.rs
@@ -96,25 +96,16 @@ pub async fn put_me_password(
     body.validate().map_err(|_| StatusCode::BAD_REQUEST)?;
     let session_id = cookie.get("session_id").ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let display_id = state
-        .get_display_id_by_session_id(session_id)
+    let id = state
+        .get_user_id_by_session_id(session_id)
         .await
         .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
         .ok_or(StatusCode::UNAUTHORIZED)?;
 
-    let user = state
-        .get_user_by_display_id(display_id)
-        .await
-        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
-        .ok_or(StatusCode::INTERNAL_SERVER_ERROR)?;
-
-    match state
-        .verify_user_password(user.id, &body.old_password)
-        .await
-    {
+    match state.verify_user_password(id, &body.old_password).await {
         Ok(true) => {
             state
-                .update_user_password(user.id, &body.new_password)
+                .update_user_password(id, &body.new_password)
                 .await
                 .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
             Ok(StatusCode::NO_CONTENT)

--- a/src/repository/users_session.rs
+++ b/src/repository/users_session.rs
@@ -1,4 +1,4 @@
-use super::Repository;
+use super::{users::UserId, Repository};
 use anyhow::Context;
 use async_session::{Session, SessionStore};
 
@@ -38,13 +38,20 @@ impl Repository {
         Ok(Some(()))
     }
 
-    pub async fn get_user_id_by_session_id(&self, session_id: &str) -> anyhow::Result<Option<i64>> {
+    pub async fn get_user_id_by_session_id(
+        &self,
+        session_id: &str,
+    ) -> anyhow::Result<Option<UserId>> {
         let session = self
             .session_store
             .load_session(session_id.to_string())
             .await?;
 
-        Ok(session.and_then(|s| s.get("user_id")))
+        let user_id = session
+            .and_then(|s| s.get("user_id"))
+            .map(|id: uuid::Uuid| UserId::new(id));
+
+        Ok(user_id)
     }
 
     pub async fn get_display_id_by_session_id(


### PR DESCRIPTION
## 関連Issue

- #40 

## 概要

`put_me_password` で  `id` しか使用していなかったため、 `get_user_id_by_session_id` を呼ぶように変更しました。
また、 `get_user_id_by_session_id` の返り値の型がなぜか `i64` になっていたため、 `UserId` に変更しました。


## 変更内容

- `put_me_password` ハンドラで `get_user_id_by_session_id` を呼ぶように変更
-  `get_user_id_by_session_id` の返り値の型を `anyhow::Result<Option<i64>>` -> `anyhow::Result<Option<UserId>>` に変更

## 補足
