### PR TITLE
POST /reset-password/request を実装

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -12,7 +12,11 @@ pub fn make_router(app_state: Repository) -> Router {
     let authentication_router = Router::new()
         .route("/signup/request", post(authentication::sign_up_request))
         .route("/signup", post(authentication::sign_up))
-        .route("/login", post(authentication::login));
+        .route("/login", post(authentication::login))
+        .route(
+            "/reset-password/request",
+            post(authentication::reset_password_request),
+        );
 
     let users_router = Router::new()
         .route("/me", get(users::get_me).put(users::put_me))

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -18,7 +18,7 @@ pub fn make_router(app_state: Repository) -> Router {
             "/reset-password/request",
             post(authentication::reset_password_request),
         );
-  
+
     let users_router = Router::new()
         .route("/me", get(users::get_me).put(users::put_me))
         .route("/me/email", put(users::put_me_email))

--- a/src/handler/authentication.rs
+++ b/src/handler/authentication.rs
@@ -140,3 +140,40 @@ pub async fn login(
 
     Ok((StatusCode::OK, headers))
 }
+
+#[derive(Deserialize)]
+pub struct ResetPasswordRequest {
+    email: String,
+}
+
+pub async fn reset_password_request(
+    State(state): State<Repository>,
+    Json(body): Json<ResetPasswordRequest>,
+) -> Result<StatusCode, StatusCode> {
+    let user_address = body
+        .email
+        .parse::<Address>()
+        .map_err(|_| StatusCode::BAD_REQUEST)?;
+
+    // 既に登録されているメールアドレスのとき、正常時と同じステータスコードを返すが実際にメールを送信しない
+    if let Ok(false) = state.is_exist_email(&body.email).await {
+        return Ok(StatusCode::CREATED);
+    }
+
+    let jwt = state
+        .encode_email_reset_password_jwt(&body.email)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let message = format!(
+        "これはテストメールです。
+以下のリンクをクリックしてください。
+https://link/{jwt}"
+    );
+
+    crate::utils::mail::send_email(user_address, "traOJudgeパスワードリセット", &message)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    Ok(StatusCode::CREATED)
+}

--- a/src/handler/authentication.rs
+++ b/src/handler/authentication.rs
@@ -179,7 +179,7 @@ pub async fn reset_password_request(
         .parse::<Address>()
         .map_err(|_| StatusCode::BAD_REQUEST)?;
 
-    // 既に登録されているメールアドレスのとき、正常時と同じステータスコードを返すが実際にメールを送信しない
+    // 登録されていないメールアドレスのとき、正常時と同じステータスコードを返すが実際にメールを送信しない
     if let Ok(false) = state.is_exist_email(&body.email).await {
         return Ok(StatusCode::CREATED);
     }

--- a/src/repository/jwt.rs
+++ b/src/repository/jwt.rs
@@ -99,6 +99,23 @@ impl Repository {
         claims.to_jwt()
     }
 
+    pub async fn encode_email_reset_password_jwt(&self, email: &str) -> anyhow::Result<String> {
+        let exp = (Utc::now() + Duration::minutes(60)).timestamp();
+        let iat = Utc::now().timestamp();
+        let nbf = Utc::now().timestamp();
+
+        let claims = EmailToken {
+            exp,
+            iat,
+            nbf,
+            user_id: None,
+            email: email.to_string(),
+            action: Action::reset_password,
+        };
+
+        claims.to_jwt()
+    }
+
     pub async fn verify_email_jwt(&self, jwt: &str) -> anyhow::Result<()> {
         EmailToken::verify(jwt)
     }


### PR DESCRIPTION
## 関連Issue

- close #19 

## 概要

POST /reset-password/request のハンドラ を実装しました

## 変更内容

- `reset_password_request` を実装
- `encode_email_reset_password_jwt` を実装

## 補足
