### PR TITLE
Feat #71 GET /submissions/{submissionId} を実装する

### DIFF
--- a/src/handler.rs
+++ b/src/handler.rs
@@ -7,6 +7,7 @@ use super::Repository;
 
 mod authentication;
 mod users;
+mod submissions;
 
 pub fn make_router(app_state: Repository) -> Router {
     let authentication_router = Router::new()
@@ -26,8 +27,12 @@ pub fn make_router(app_state: Repository) -> Router {
         .route("/me/password", put(users::put_me_password))
         .route("/:userId", get(users::get_user));
 
+    let submissions_router = Router::new()
+        .route("/:submissionId", get(submissions::get_submission));
+
     Router::new()
         .nest("/", authentication_router)
         .nest("/users", users_router)
+        .nest("/submissions", submissions_router)
         .with_state(app_state)
 }

--- a/src/handler.rs
+++ b/src/handler.rs
@@ -6,8 +6,8 @@ use axum::{
 use super::Repository;
 
 mod authentication;
-mod users;
 mod submissions;
+mod users;
 
 pub fn make_router(app_state: Repository) -> Router {
     let authentication_router = Router::new()
@@ -27,8 +27,8 @@ pub fn make_router(app_state: Repository) -> Router {
         .route("/me/password", put(users::put_me_password))
         .route("/:userId", get(users::get_user));
 
-    let submissions_router = Router::new()
-        .route("/:submissionId", get(submissions::get_submission));
+    let submissions_router =
+        Router::new().route("/:submissionId", get(submissions::get_submission));
 
     Router::new()
         .nest("/", authentication_router)

--- a/src/handler/submissions.rs
+++ b/src/handler/submissions.rs
@@ -1,4 +1,8 @@
-use axum::{extract::{Path, State}, response::IntoResponse, Json};
+use axum::{
+    extract::{Path, State},
+    response::IntoResponse,
+    Json,
+};
 use axum_extra::{headers::Cookie, TypedHeader};
 use reqwest::StatusCode;
 use serde::Serialize;
@@ -39,7 +43,6 @@ pub async fn get_submission(
     TypedHeader(cookie): TypedHeader<Cookie>,
     Path(path): Path<i64>,
 ) -> anyhow::Result<impl IntoResponse, StatusCode> {
-
     let submission = state
         .get_submission_by_id(path)
         .await
@@ -62,7 +65,7 @@ pub async fn get_submission(
             .ok_or(StatusCode::NOT_FOUND)?;
 
         if display_id != problem.author_id {
-            return Err(StatusCode::NOT_FOUND)
+            return Err(StatusCode::NOT_FOUND);
         }
     }
 

--- a/src/handler/submissions.rs
+++ b/src/handler/submissions.rs
@@ -1,0 +1,75 @@
+use axum::{extract::{Path, State}, response::IntoResponse, Json};
+use reqwest::StatusCode;
+use serde::Serialize;
+use sqlx::types::chrono;
+
+use super::Repository;
+
+#[derive(Debug, Serialize)]
+struct SubmissionResponse {
+    id: String,
+    user_id: i32,
+    user_name: String,
+    problem_id: i32,
+    submitted_at: chrono::DateTime<chrono::Utc>,
+    language_id: i32,
+    total_score: i64,
+    max_time: i32,
+    max_memory: i32,
+    code_length: i32,
+    overall_judge_status: String,
+    judge_results: Vec<TestcaseResponse>,
+}
+
+#[derive(Debug, Serialize)]
+struct TestcaseResponse {
+    testcase_id: i32,
+    testcase_name: String,
+    judge_status: String,
+    score: i64,
+    time: i32,
+    memory: i32,
+}
+
+pub async fn get_submission(
+    State(state): State<Repository>,
+    Path(path): Path<i64>,
+) -> anyhow::Result<impl IntoResponse, StatusCode> {
+    let submission = state
+        .get_submission_by_id(path)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?
+        .ok_or(StatusCode::NOT_FOUND)?;
+
+    let testcases = state
+        .get_testcases_by_submission_id(submission.id)
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+
+    let response = SubmissionResponse {
+        id: submission.id.to_string(),
+        user_id: submission.user_id,
+        user_name: submission.user_name,
+        problem_id: submission.problem_id,
+        submitted_at: submission.submitted_at,
+        language_id: submission.language_id,
+        total_score: submission.total_score,
+        max_time: submission.max_time,
+        max_memory: submission.max_memory,
+        code_length: submission.source.len() as i32,
+        overall_judge_status: submission.judge_status,
+        judge_results: testcases
+            .into_iter()
+            .map(|testcase| TestcaseResponse {
+                testcase_id: testcase.testcase_id,
+                testcase_name: testcase.testcase_name,
+                judge_status: testcase.judge_status,
+                score: testcase.score,
+                time: testcase.time,
+                memory: testcase.memory,
+            })
+            .collect(),
+    };
+
+    Ok(Json(response))
+}

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -4,11 +4,11 @@ use sqlx::mysql::{MySqlConnectOptions, MySqlPoolOptions};
 use super::Repository;
 
 mod jwt;
+mod normal_problems;
+mod submissions;
 mod user_password;
 pub mod users;
 mod users_session;
-mod submissions;
-mod normal_problems;
 
 impl Repository {
     pub async fn connect() -> anyhow::Result<Self> {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,6 +7,7 @@ mod jwt;
 mod user_password;
 pub mod users;
 mod users_session;
+pub mod submissions;
 
 impl Repository {
     pub async fn connect() -> anyhow::Result<Self> {

--- a/src/repository.rs
+++ b/src/repository.rs
@@ -7,7 +7,8 @@ mod jwt;
 mod user_password;
 pub mod users;
 mod users_session;
-pub mod submissions;
+mod submissions;
+mod normal_problems;
 
 impl Repository {
     pub async fn connect() -> anyhow::Result<Self> {

--- a/src/repository/normal_problems.rs
+++ b/src/repository/normal_problems.rs
@@ -1,0 +1,28 @@
+use super::Repository;
+use sqlx::types::chrono;
+
+#[derive(sqlx::FromRow)]
+pub struct NormalProblems {
+    pub id: i32,
+    pub author_id: i64,
+    pub title: String,
+    pub statement: String,
+    pub time_limit: i32,
+    pub memory_limit: i32,
+    pub difficulty: i32,
+    pub is_public: bool,
+    pub judgecode_path: String,
+    pub created_at: chrono::DateTime<chrono::Utc>,
+    pub updated_at: chrono::DateTime<chrono::Utc>,
+}
+
+impl Repository {
+    pub async fn get_normal_problem_by_id(&self, id: i32) -> anyhow::Result<Option<NormalProblems>> {
+        let problem = sqlx::query_as::<_, NormalProblems>("SELECT * FROM normal_problems WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(problem)
+    }
+}

--- a/src/repository/normal_problems.rs
+++ b/src/repository/normal_problems.rs
@@ -17,11 +17,15 @@ pub struct NormalProblems {
 }
 
 impl Repository {
-    pub async fn get_normal_problem_by_id(&self, id: i32) -> anyhow::Result<Option<NormalProblems>> {
-        let problem = sqlx::query_as::<_, NormalProblems>("SELECT * FROM normal_problems WHERE id = ?")
-            .bind(id)
-            .fetch_optional(&self.pool)
-            .await?;
+    pub async fn get_normal_problem_by_id(
+        &self,
+        id: i32,
+    ) -> anyhow::Result<Option<NormalProblems>> {
+        let problem =
+            sqlx::query_as::<_, NormalProblems>("SELECT * FROM normal_problems WHERE id = ?")
+                .bind(id)
+                .fetch_optional(&self.pool)
+                .await?;
 
         Ok(problem)
     }

--- a/src/repository/submissions.rs
+++ b/src/repository/submissions.rs
@@ -1,0 +1,49 @@
+use sqlx::{FromRow, types::chrono};
+
+use super::Repository;
+
+#[derive(FromRow)]
+pub struct Submission {
+    pub id: i32,
+    pub problem_id: i32,
+    pub user_id: i32,
+    pub user_name: String,
+    pub language_id: i32,
+    pub source: String,
+    pub judge_status: String,
+    pub total_score: i64,
+    pub max_time: i32,
+    pub max_memory: i32,
+    pub submitted_at: chrono::DateTime<chrono::Utc>,
+}
+
+#[derive(FromRow)]
+pub struct Testcase {
+    pub submission_id: i32,
+    pub testcase_id: i32,
+    pub testcase_name: String,
+    pub judge_status: String,
+    pub score: i64,
+    pub time: i32,
+    pub memory: i32,
+}
+
+impl Repository {
+    pub async fn get_submission_by_id(&self, id: i64) -> anyhow::Result<Option<Submission>> {
+        let submission = sqlx::query_as::<_, Submission>("SELECT * FROM submissions WHERE id = ?")
+            .bind(id)
+            .fetch_optional(&self.pool)
+            .await?;
+
+        Ok(submission)
+    }
+
+    pub async fn get_testcases_by_submission_id(&self, submission_id: i32) -> anyhow::Result<Vec<Testcase>> {
+        let testcases = sqlx::query_as::<_, Testcase>("SELECT * FROM testcases WHERE submission_id = ?")
+            .bind(submission_id)
+            .fetch_all(&self.pool)
+            .await?;
+
+        Ok(testcases)
+    }
+}

--- a/src/repository/submissions.rs
+++ b/src/repository/submissions.rs
@@ -1,4 +1,4 @@
-use sqlx::{FromRow, types::chrono};
+use sqlx::{types::chrono, FromRow};
 
 use super::Repository;
 
@@ -38,11 +38,15 @@ impl Repository {
         Ok(submission)
     }
 
-    pub async fn get_testcases_by_submission_id(&self, submission_id: i32) -> anyhow::Result<Vec<Testcase>> {
-        let testcases = sqlx::query_as::<_, Testcase>("SELECT * FROM testcases WHERE submission_id = ?")
-            .bind(submission_id)
-            .fetch_all(&self.pool)
-            .await?;
+    pub async fn get_testcases_by_submission_id(
+        &self,
+        submission_id: i32,
+    ) -> anyhow::Result<Vec<Testcase>> {
+        let testcases =
+            sqlx::query_as::<_, Testcase>("SELECT * FROM testcases WHERE submission_id = ?")
+                .bind(submission_id)
+                .fetch_all(&self.pool)
+                .await?;
 
         Ok(testcases)
     }


### PR DESCRIPTION
## 関連Issue

- close #71

## 概要

GET /submissions/{submissionId} を実装

## 変更内容

- `get_submission`として実装
- データベースへのアクセス: `get_submission_by_id`, `get_testcases_by_submission_id`として実装
- `get_normal_problems_by_id`の実装

## 補足
問題が公開でないかつ作問者でないときに404エラーを返す